### PR TITLE
Safari Layout Fixes

### DIFF
--- a/_sass/team.scss
+++ b/_sass/team.scss
@@ -6,6 +6,7 @@
 .person {
   overflow: hidden;
   display: flex;
+  align-items: flex-start;
   margin: 20px 0;
 
   .picture {

--- a/_sass/team.scss
+++ b/_sass/team.scss
@@ -11,6 +11,7 @@
   .picture {
     max-width: 50%;
     object-fit: contain;
+    object-position: 0% 0%;
     flex: 0 0 auto;
   }
 


### PR DESCRIPTION
Fix for the bug where images would appear out of line compares to the associated text items as well as the massive gaps between rows.