### PR TITLE
Hide site name when on mobile

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,8 @@
                 <!-- Social icons from Font Awesome, if enabled -->
                 {% include icons.html %}
                 </ul>
+                <br>    
+                <a href = "/"><img src="/assets/img/logo/circle.png" alt="Hackathons for Schools Association" width="30%" /></a>
             </div>
 </footer>
 

--- a/_sass/includes/_navbar.scss
+++ b/_sass/includes/_navbar.scss
@@ -15,7 +15,7 @@
 
 .site-header {
   //padding-bottom: 1%;
-  padding: 2% 2% 1% 2%;
+  padding: 2% 2% 1% 2%; 
   background: $brand-color;
   display: inline-block;
   float: left;
@@ -92,6 +92,12 @@
 
 /* ---- Responsive ---- */
 
+@media(max-width: 1200px) {
+  .site-title {
+    display: none;
+  }
+}
+
 @media (min-width: $break) {
   a#pull {
     display: none;
@@ -133,7 +139,8 @@
       li {
         width: 100%;
         text-align: center;
-        font-size: 1em;
+        font-size: 2em;
+        margin-top: 16px;
         position: relative;
         background-color: darken($background-color, 2%);
 

--- a/_sass/includes/_navbar.scss
+++ b/_sass/includes/_navbar.scss
@@ -123,7 +123,6 @@
     }
 
     ul {
-      width: 100%;
       overflow: hidden;
 
       /* fade out, then shrink */


### PR DESCRIPTION
## Changes

- Site name disappears on screen sizes smaller than `1200px`
- Mobile hamburger menu displays text larger
- Site logo displayed in the footer

---

I would like the [hamburger menu to be redesigned](https://github.com/hackathonsforschools/website/issues/12), so the animation comes directly from the top of the screen rather than zooming in. Also, making each option a button sort of thing. Something that's a bit more friendly to touch as the narrow lines aren't great currently. @danielfspencer could you have a look in a future PR? 