### PR TITLE
Updated broken mentors link

### DIFF
--- a/pages/2_get-started.md
+++ b/pages/2_get-started.md
@@ -24,4 +24,4 @@ We've built a large number of resources to help you get started with planning yo
 
 We can also put you in contact with one of our mentors! They all have experience attending hackathons so understand the core concepts of a hcakthon. Some of our mentors have even organised hackathons around the country. They can help you with any questions you have about your event!  Get in contact if this is something you're interested in. We can definitely help!
 
-Our mentors can run a workshop for you at your event, helping students learn new skills to create cool projects. If you had a particular area you wanted your workshop on, have a look at what skills our mentors have on the [Mentors page](/mentor/). If you'd like a mentor to come to your event, get in contact via [email](mailto:hello@hackthonsforschools.com).
+Our mentors can run a workshop for you at your event, helping students learn new skills to create cool projects. If you had a particular area you wanted your workshop on, have a look at what skills our mentors have on the [Mentors page](/mentors/). If you'd like a mentor to come to your event, get in contact via [email](mailto:hello@hackthonsforschools.com).


### PR DESCRIPTION
Literally just added a '**s**' to the link to mentors from the get started page.